### PR TITLE
Fix for issue #29: No stack trace for "Unexpected error"

### DIFF
--- a/collatex-tools/src/main/java/eu/interedition/collatex/tools/CollateX.java
+++ b/collatex-tools/src/main/java/eu/interedition/collatex/tools/CollateX.java
@@ -58,6 +58,7 @@ public class CollateX {
             error("Script error", e);
         } catch (Throwable t) {
             error("Unexpected error", t);
+            t.printStackTrace(ERROR_LOG);
         } finally {
             ERROR_LOG.flush();
         }


### PR DESCRIPTION
Print a stack trace on "unexpected errors".