### PR TITLE
Added type attribute on app when a column does not contain a variant.

### DIFF
--- a/collatex-pythonport/collatex/core_functions.py
+++ b/collatex-pythonport/collatex/core_functions.py
@@ -115,6 +115,8 @@ def export_alignment_table_as_xml(table):
     readings = []
     for column in table.columns:
         app = etree.Element('app')
+        if not column.variant:
+            app.set("type", "invariant")
         for key, value in sorted(column.tokens_per_witness.items()):
             child = etree.Element('rdg')
             child.attrib['wit'] = "#" + key


### PR DESCRIPTION
Hello, @ebeshero and I have been working on a collation and realized that it would be necessary for us to know whether a table object row contains normalized tokens that agree or not. So we added an attribute to `<app>` in the XML output that indicates whether the children `<rdg>`s agree. Example:

```xml
<app type="invariant">
    <rdg wit="#f1818">We were strangers to any species </rdg>
    <rdg wit="#f1823">We were strangers to any species </rdg>
    <rdg wit="#fMSc56">We were strangers &lt;lb/&gt;to any species </rdg>
</app>
```
In the example above the string `&lt;lb/&gt;` is set to be normalized away during the collation process; yet we need to see it in the output for project-specific reasons. This way would indicate alignment but keep the witnesses separate.

For further reference, you can find our project here: https://github.com/ebeshero/Pittsburgh_Frankenstein/tree/Text_Processing