### PR TITLE
Set timeout on dot process

### DIFF
--- a/collatex-servlet/src/main/java/eu/interedition/collatex/io/VariantGraphSVGMessageBodyWriter.java
+++ b/collatex-servlet/src/main/java/eu/interedition/collatex/io/VariantGraphSVGMessageBodyWriter.java
@@ -85,7 +85,10 @@ public class VariantGraphSVGMessageBodyWriter implements MessageBodyWriter<Varia
                     }, processThreads),
                     CompletableFuture.runAsync(() -> {
                         try {
-                            if (dotProc.waitFor() != 0) {
+                            if (!dotProc.waitFor(1,TimeUnit.HOURS)) {
+                                throw new CompletionException(new RuntimeException("dot processing took longer than 1 hour, process was timed out."));
+                            }
+                            if (dotProc.exitValue() != 0) {
                                 throw new CompletionException(new IllegalStateException(errors.toString()));
                             }
                         } catch (InterruptedException e) {

--- a/collatex-tools/src/main/java/eu/interedition/collatex/tools/CollationServer.java
+++ b/collatex-tools/src/main/java/eu/interedition/collatex/tools/CollationServer.java
@@ -243,7 +243,10 @@ public class CollationServer {
                             }, processThreads),
                             CompletableFuture.runAsync(() -> {
                                 try {
-                                    if (dotProc.waitFor() != 0) {
+                                    if (!dotProc.waitFor(60,TimeUnit.SECONDS)) {
+                                        throw new CompletionException(new RuntimeException("dot processing took longer than 60 seconds, process was timed out."));
+                                    }
+                                    if (dotProc.exitValue() != 0) {
                                         throw new CompletionException(new IllegalStateException(errors.toString()));
                                     }
                                 } catch (InterruptedException e) {


### PR DESCRIPTION
A combination of a complex graph and an older version of the dot executable can lead the dot conversion to become stuck in a loop, meaning the dot process doesn't finish.
Adding a timeout to the `dotProc.waitFor()` should at least kill this hanging process after the timeout period.