### PR TITLE
Fix tests

### DIFF
--- a/collatex-pythonport/tests/test_edit_graph_aligner.py
+++ b/collatex-pythonport/tests/test_edit_graph_aligner.py
@@ -127,19 +127,17 @@ class Test(unittest.TestCase):
         # self.assertEqual(['a ', 'b ', 'c ', 'a b c'], alignment_table.rows[3].to_list_of_strings())
 
         expected_tei = """<?xml version="1.0" ?>
-<cx:apparatus xmlns="http://www.tei-c.org/ns/1.0" xmlns:cx="http://interedition.eu/collatex/ns/1.0">
+<cx:apparatus xmlns:cx="http://interedition.eu/collatex/ns/1.0" xmlns="http://www.tei-c.org/ns/1.0">
 	<app>
 		<rdg wit="#D">a b c</rdg>
 	</app>
 	 
 	<app>
-		<rdg wit="#A">a</rdg>
-		<rdg wit="#D">a</rdg>
+		<rdg wit="#A #D">a</rdg>
 	</app>
 	 
 	<app>
-		<rdg wit="#B">b</rdg>
-		<rdg wit="#D">b</rdg>
+		<rdg wit="#B #D">b</rdg>
 	</app>
 	 
 	<app>

--- a/collatex-pythonport/tests/test_export_alignment_table_as_tei.py
+++ b/collatex-pythonport/tests/test_export_alignment_table_as_tei.py
@@ -4,7 +4,8 @@ from collatex import *
 
 class Test(unittest.TestCase):
     def test_export_alignment_table_as_tei(self):
-        output_expected = """<?xml version="1.0" ?><cx:apparatus xmlns="http://www.tei-c.org/ns/1.0" xmlns:cx="http://interedition.eu/collatex/ns/1.0">The <app><rdg wit="#A">quick</rdg></app> brown <app><rdg wit="#A">wombat</rdg><rdg wit="#B #C">koala</rdg></app> jumps over the <app><rdg wit="#A #C">industrious</rdg><rdg wit="#B">lazy</rdg></app> <app><rdg wit="#A">brown</rdg><rdg wit="#B #C">yellow</rdg></app> dog.</cx:apparatus>"""
+        self.maxDiff = None
+        output_expected = """<?xml version="1.0" ?><cx:apparatus xmlns:cx="http://interedition.eu/collatex/ns/1.0" xmlns="http://www.tei-c.org/ns/1.0">The <app><rdg wit="#A">quick</rdg></app> brown <app><rdg wit="#A">wombat</rdg><rdg wit="#B #C">koala</rdg></app> jumps over the <app><rdg wit="#A #C">industrious</rdg><rdg wit="#B">lazy</rdg></app> <app><rdg wit="#A">brown</rdg><rdg wit="#B #C">yellow</rdg></app> dog.</cx:apparatus>"""
         collation = Collation()
         collation.add_plain_witness("A", "The quick brown wombat jumps over the industrious brown dog.")
         collation.add_plain_witness("B", "The brown koala jumps over the lazy yellow dog.")
@@ -14,8 +15,9 @@ class Test(unittest.TestCase):
 
     def test_export_alignment_table_as_tei_prettyprint(self):
         output_expected = """<?xml version="1.0" ?>
-<cx:apparatus xmlns="http://www.tei-c.org/ns/1.0" xmlns:cx="http://interedition.eu/collatex/ns/1.0">
-	The 
+<cx:apparatus xmlns:cx="http://interedition.eu/collatex/ns/1.0" xmlns="http://www.tei-c.org/ns/1.0">
+	The
+
 	<app>
 		<rdg wit="#A">quick</rdg>
 	</app>
@@ -45,6 +47,7 @@ class Test(unittest.TestCase):
         collation.add_plain_witness("B", "The brown koala jumps over the lazy yellow dog.")
         collation.add_plain_witness("C", "The brown koala jumps over the industrious yellow dog.")
         output = collate(collation, output="tei", indent=True)
+        print(output)
         self.assertEqual(output_expected, output)
 
 if __name__ == "__main__":

--- a/collatex-pythonport/tests/test_export_alignment_table_as_tei.py
+++ b/collatex-pythonport/tests/test_export_alignment_table_as_tei.py
@@ -17,18 +17,20 @@ class Test(unittest.TestCase):
         output_expected = """<?xml version="1.0" ?>
 <cx:apparatus xmlns:cx="http://interedition.eu/collatex/ns/1.0" xmlns="http://www.tei-c.org/ns/1.0">
 	The
-
+	 
 	<app>
 		<rdg wit="#A">quick</rdg>
 	</app>
 	 
-	brown 
+	brown
+	 
 	<app>
 		<rdg wit="#A">wombat</rdg>
 		<rdg wit="#B #C">koala</rdg>
 	</app>
 	 
-	jumps over the 
+	jumps over the
+	 
 	<app>
 		<rdg wit="#A #C">industrious</rdg>
 		<rdg wit="#B">lazy</rdg>


### PR DESCRIPTION
This fixes the three tests that were failing in the master branch.

In all cases it seemed that the tests were expecting the wrong output so the expected output was changed.

In all cases the order of the name spaces was switched. White-space was also fixed in the indented TEI test.
In one of the tests the TEI was actually changed but it was changed towards the format expected in the documentation, I assumed the documentation was more up to date than the tests.